### PR TITLE
Grain types are now fully qualified. Upgraded to .NET 8 and Orleans v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Pack All Projects
         run: dotnet pack --configuration Release -p:Version=${GITHUB_REF##*/v} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ builder.Host
     );
 ```
 
+### Using Fully Qualified Grain Types
+Versions greater than v7.2.1 of this library fully qualify the grain type names to avoid grain type conflicts with grains from your own application. 
+
+#### Existing deployments with v7.2.1 and below
+Up to v7.2.1 of this library, if your own project contained any grain type names that are the same as a grain created by this library, such as `UserGrain`, then your silo would fail to start, because Orleans cannot differentiate between the two grain types.
+
+If you have an existing deployment with v7.2.1 or earlier, and upgrade this library, **Fully Qualified Grain Types are considered a breaking change**, and you may experience issues as the grain type names will no longer be backwards compatible. If this is the case, you should set `UseFullyQualifiedGrainTypes` to false to keep the v7.2.1  behaviour of this library.
+
+```cs
+.AddSignalRBackplane(options => options.UseFullyQualifiedGrainTypes = false)
+```
+
+If you disable fully qualified grain types, you must ensure that your grain type names do not conflict with the grain types created by this library. This can be done by [decorating your own types](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-identity#grain-type-names).
+
 ## Adding SignalR to the server
 Adding this backplane does not register the SignalR services that are required to make real-time client-to-server and server-to-client possible. We leave this to you as there are a number of configurations you may want to make when doing this. For out-of-the-box configuration, you can call the `AddSignalR` extension on the `IServiceCollection`:
 

--- a/samples/OrleansClient/OrleansClient.csproj
+++ b/samples/OrleansClient/OrleansClient.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Server/Server.csproj
+++ b/samples/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Shared/Shared.csproj
+++ b/samples/Shared/Shared.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="7.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
   </ItemGroup>
 
 

--- a/samples/SignalRClient/SignalRClient.csproj
+++ b/samples/SignalRClient/SignalRClient.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.10" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.1" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UFX.Orleans.SignalRBackplane.Abstractions/UFX.Orleans.SignalRBackplane.Abstractions.csproj
+++ b/src/UFX.Orleans.SignalRBackplane.Abstractions/UFX.Orleans.SignalRBackplane.Abstractions.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="7.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/UFX.Orleans.SignalRBackplane.Client/UFX.Orleans.SignalRBackplane.Client.csproj
+++ b/src/UFX.Orleans.SignalRBackplane.Client/UFX.Orleans.SignalRBackplane.Client.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Client" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UFX.Orleans.SignalRBackplane/Grains/GrainInterfaceTypeProvider.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/GrainInterfaceTypeProvider.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+
+namespace UFX.Orleans.SignalRBackplane.Grains;
+
+internal class GrainInterfaceTypeProvider(IOptions<SignalrOrleansOptions> options) : IGrainInterfaceTypeProvider
+{
+    public bool TryGetGrainInterfaceType(Type type, out GrainInterfaceType grainInterfaceType)
+    {
+        var useFullyQualifiedGrainType = options.Value.UseFullyQualifiedGrainTypes
+                                         && type.FullName is not null
+                                         && typeof(IGrain).IsAssignableFrom(type)
+                                         && type.Assembly.FullName!.StartsWith("UFX.Orleans.SignalRBackplane");
+
+        grainInterfaceType = useFullyQualifiedGrainType ? GrainInterfaceType.Create(type.FullName!) : default;
+        return useFullyQualifiedGrainType;
+    }
+}

--- a/src/UFX.Orleans.SignalRBackplane/Grains/GrainTypeProvider.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/GrainTypeProvider.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Options;
+using Orleans.Metadata;
+using Orleans.Runtime;
+
+namespace UFX.Orleans.SignalRBackplane.Grains;
+
+internal class GrainTypeProvider(IOptions<SignalrOrleansOptions> options): IGrainTypeProvider
+{
+    public bool TryGetGrainType(Type type, out GrainType grainType)
+    {
+        var useFullyQualifiedGrainType = options.Value.UseFullyQualifiedGrainTypes
+                                         && type.FullName is not null
+                                         && typeof(SignalrBaseGrain).IsAssignableFrom(type)
+                                         && type.Assembly.FullName!.StartsWith("UFX.Orleans.SignalRBackplane");
+
+        grainType = useFullyQualifiedGrainType ? GrainType.Create(type.FullName!) : default;
+        return useFullyQualifiedGrainType;
+    }
+}

--- a/src/UFX.Orleans.SignalRBackplane/ReminderResolver.cs
+++ b/src/UFX.Orleans.SignalRBackplane/ReminderResolver.cs
@@ -4,7 +4,7 @@ namespace UFX.Orleans.SignalRBackplane;
 
 internal interface IReminderResolver
 {
-    Task<IGrainReminder> GetReminder(IGrainBase grainBase, string reminderName);
+    Task<IGrainReminder?> GetReminder(IGrainBase grainBase, string reminderName);
 }
 
 /// <summary>
@@ -13,6 +13,6 @@ internal interface IReminderResolver
 /// </summary>
 internal class ReminderResolver : IReminderResolver
 {
-    public Task<IGrainReminder> GetReminder(IGrainBase grainBase, string reminderName) 
+    public Task<IGrainReminder?> GetReminder(IGrainBase grainBase, string reminderName) 
         => grainBase.GetReminder(reminderName);
 }

--- a/src/UFX.Orleans.SignalRBackplane/SignalrOrleansOptions.cs
+++ b/src/UFX.Orleans.SignalRBackplane/SignalrOrleansOptions.cs
@@ -3,4 +3,5 @@
 public class SignalrOrleansOptions
 {
     public TimeSpan GrainCleanupPeriod { get; set; } = TimeSpan.FromDays(1);
+    public bool UseFullyQualifiedGrainTypes { get; set; } = true;
 }

--- a/src/UFX.Orleans.SignalRBackplane/SiloBuilderExtensions.cs
+++ b/src/UFX.Orleans.SignalRBackplane/SiloBuilderExtensions.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Metadata;
+using Orleans.Runtime;
+using UFX.Orleans.SignalRBackplane.Grains;
 
 namespace UFX.Orleans.SignalRBackplane;
 
@@ -15,6 +18,8 @@ public static class SiloBuilderExtensions
         }
 
         services
+            .AddSingleton<IGrainTypeProvider, GrainTypeProvider>()
+            .AddSingleton<IGrainInterfaceTypeProvider, GrainInterfaceTypeProvider>()
             .AddSingleton(typeof(HubLifetimeManager<>), typeof(OrleansHubLifetimeManager<>))
             .AddSingleton<IReminderResolver, ReminderResolver>();
 

--- a/src/UFX.Orleans.SignalRBackplane/UFX.Orleans.SignalRBackplane.csproj
+++ b/src/UFX.Orleans.SignalRBackplane/UFX.Orleans.SignalRBackplane.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UFX.Orleans.SignalRBackplane.Client.Tests/UFX.Orleans.SignalRBackplane.Client.Tests.csproj
+++ b/tests/UFX.Orleans.SignalRBackplane.Client.Tests/UFX.Orleans.SignalRBackplane.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/UFX.Orleans.SignalRBackplane.Tests/SignalrBaseGrainTests.cs
+++ b/tests/UFX.Orleans.SignalRBackplane.Tests/SignalrBaseGrainTests.cs
@@ -79,7 +79,7 @@ namespace UFX.Orleans.SignalRBackplane.Tests
             var reminderResolver = A.Fake<IReminderResolver>();
             
             A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
-            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder?>(null!);
 
             var grain = new TestGrain(
                 persistentState,
@@ -106,7 +106,7 @@ namespace UFX.Orleans.SignalRBackplane.Tests
             var reminderResolver = A.Fake<IReminderResolver>();
 
             A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
-            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder?>(null!);
 
             var grain = new TestGrain(
                 persistentState,
@@ -135,7 +135,7 @@ namespace UFX.Orleans.SignalRBackplane.Tests
             var reminderResolver = A.Fake<IReminderResolver>();
 
             A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
-            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder?>(null!);
 
             var grain = new TestGrain(
                 persistentState,
@@ -163,7 +163,7 @@ namespace UFX.Orleans.SignalRBackplane.Tests
             var reminderResolver = A.Fake<IReminderResolver>();
 
             A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
-            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder?>(null!);
 
             var grain = new TestGrain(
                 persistentState,

--- a/tests/UFX.Orleans.SignalRBackplane.Tests/UFX.Orleans.SignalRBackplane.Tests.csproj
+++ b/tests/UFX.Orleans.SignalRBackplane.Tests/UFX.Orleans.SignalRBackplane.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Would recommend releasing this as v8.0.0 of the library

- Library now fully qualifies the grain type names to avoid grain type conflicts with grains from end users' own applications. See conversation with Orleans maintainer around this here https://github.com/dotnet/orleans/issues/8846. **Note this is a breaking change** for anyone currently using the library, but I added an optional config flag to continue using the old behaviour for anyone wishing to avoid the breaking change in their current silos.
- Upgraded .NET to 8.0
- Upgraded Orleans to 8.0.0